### PR TITLE
Update MIT license metadata

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2025 Kevon Houghton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- add owner name and year to MIT license

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855c2fe6ea48324b670420086443cfc