### PR TITLE
Fix card layout shift

### DIFF
--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -20,7 +20,7 @@ else
     {
         <div class="bg-blue-100 border border-blue-300 text-blue-800 rounded-lg p-6 mb-6">
             <h4 class="text-lg font-semibold mb-2">No Active Template</h4>
-            <p class="mb-4">You don't have an active template. Start a new training plan to track your progress.</p>
+            <p class="mb-4">You don't have an active template. Create one to start tracking progress.</p>
             <a href="/templates/form" class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition">Create Template</a>
         </div>
     }

--- a/Components/Pages/WorkoutTemplateCreate.razor
+++ b/Components/Pages/WorkoutTemplateCreate.razor
@@ -20,7 +20,7 @@
                 </div>
             </div>
             <div class="mb-3">
-                <div class="flex flex-row gap-2 overflow-x-auto flex-nowrap w-full max-w-screen sm:max-w-[calc(100vw-250px)]">
+                <div class="flex flex-row gap-2 overflow-x-auto flex-nowrap items-start w-full max-w-screen sm:max-w-[calc(100vw-250px)]">
                     @foreach (var day in template.Days.OrderBy(d => d.DayOfWeek))
                     {
                         <WorkoutTemplateDayCard Day="day"

--- a/Components/Pages/WorkoutTemplateList.razor
+++ b/Components/Pages/WorkoutTemplateList.razor
@@ -20,7 +20,7 @@
 else if (!templates.Any())
 {
     <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 rounded">
-        <p>No templates found. Create your first template to start tracking your progress.</p>
+        <p>No templates found. Get started by creating a template to track your progress.</p>
     </div>
 }
 else
@@ -33,8 +33,8 @@ else
                     <h5 class="font-semibold m-0">@template.Name</h5>
                 </div>
                 <div class="px-4 py-2 border-t flex gap-3">
-                    <a href="/templates/form/@template.Id" class="text-sm text-blue-600 hover:text-blue-800">Edit</a>
-                    <a href="/templates/delete/@template.Id" class="text-sm text-red-600 hover:text-red-800">Delete</a>
+                    <a href="/templates/form/@template.Id" class="text-sm text-blue-600 hover:text-blue-800 px-2 py-1 rounded">Edit</a>
+                    <a href="/templates/delete/@template.Id" class="text-sm text-red-600 hover:text-red-800 px-2 py-1 rounded">Delete</a>
                 </div>
             </div>
         }


### PR DESCRIPTION
## Summary
- align day cards to the top so other cards don't stretch
- add padding to action links
- tweak empty template call to action wording

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856bc87b2a48324a3e8a94e14414707