### PR TITLE
Implement workout start from template

### DIFF
--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -40,9 +40,11 @@ else
                     </div>
                     <div class="md:w-1/2">
                         <div class="mt-3">
-                            <a href="#" class="inline-block bg-green-400 text-white font-medium py-3 px-4 rounded w-full opacity-60 cursor-not-allowed text-center text-lg">
-                                Start Today's Workout (feature coming soon)
-                            </a>
+                            <button type="button"
+                                    class="inline-block bg-green-600 hover:bg-green-700 text-white font-medium py-3 px-4 rounded w-full text-center text-lg"
+                                    @onclick="StartWorkoutAsync">
+                                Start Today's Workout
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -52,15 +54,3 @@ else
 }
 
 </div>
-
-@code {
-    private bool isLoading = true;
-    private Swol.Data.Models.Template.WorkoutTemplate? activeTemplate;
-
-    protected override async Task OnInitializedAsync()
-    {
-        activeTemplate = await Db.WorkoutTemplates
-            .FirstOrDefaultAsync();
-        isLoading = false;
-    }
-}

--- a/Components/Pages/Home.razor.cs
+++ b/Components/Pages/Home.razor.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.EntityFrameworkCore;
+using Swol.Data.Models.Template;
+using Swol.Data.Models.Work;
+
+namespace Swol.Components.Pages;
+
+public partial class Home : ComponentBase
+{
+    [Inject] public Data.ApplicationDbContext Db { get; set; } = default!;
+    [Inject] public NavigationManager Nav { get; set; } = default!;
+
+    private bool isLoading = true;
+    private WorkoutTemplate? activeTemplate;
+
+    protected override async Task OnInitializedAsync()
+    {
+        activeTemplate = await Db.WorkoutTemplates
+            .Include(t => t.Days)
+                .ThenInclude(d => d.Exercises)
+            .FirstOrDefaultAsync();
+        isLoading = false;
+    }
+
+    private async Task StartWorkoutAsync()
+    {
+        if (activeTemplate == null)
+            return;
+
+        var workout = new Workout
+        {
+            Name = $"{activeTemplate.Name} - {DateTime.Today:yyyy-MM-dd}",
+            WorkoutTemplateId = activeTemplate.Id,
+            StartDate = DateTime.Today,
+            IsActive = true
+        };
+
+        Db.Workouts.Add(workout);
+        await Db.SaveChangesAsync();
+
+        var template = await Db.WorkoutTemplates
+            .Include(t => t.Days)
+                .ThenInclude(d => d.Exercises)
+            .FirstAsync(t => t.Id == activeTemplate.Id);
+
+        foreach (var tDay in template.Days.OrderBy(d => d.DayNumber))
+        {
+            var wDay = new WorkoutDay
+            {
+                WorkoutId = workout.Id,
+                DayOfWeek = tDay.DayOfWeek,
+                Name = tDay.DayOfWeek.ToString()
+            };
+            Db.WorkoutDays.Add(wDay);
+            await Db.SaveChangesAsync();
+
+            foreach (var tEx in tDay.Exercises.OrderBy(e => e.OrderInDay))
+            {
+                var wEx = new WorkoutDayExercise
+                {
+                    WorkoutDayId = wDay.Id,
+                    ExerciseId = tEx.ExerciseId,
+                    OrderInDay = tEx.OrderInDay
+                };
+                Db.WorkoutDayExercises.Add(wEx);
+            }
+        }
+
+        await Db.SaveChangesAsync();
+        Nav.NavigateTo($"/workouts/{workout.Id}");
+    }
+}


### PR DESCRIPTION
## Summary
- add `Home.razor.cs` code-behind
- implement `StartWorkoutAsync` to create a new workout from the active template
- load template details on initialization
- hook up 'Start Today's Workout' button to run the new method

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c3224d988324af1a2b9c40b27c1e