### PR TITLE
Add upcoming week creation

### DIFF
--- a/Components/Pages/Home.razor.cs
+++ b/Components/Pages/Home.razor.cs
@@ -43,26 +43,35 @@ public partial class Home : ComponentBase
                 .ThenInclude(d => d.Exercises)
             .FirstAsync(t => t.Id == activeTemplate.Id);
 
-        foreach (var tDay in template.Days.OrderBy(d => d.DayNumber))
+        var startDate = workout.StartDate ?? DateTime.Today;
+
+        for (int i = 0; i < 7; i++)
         {
+            var dow = startDate.AddDays(i).DayOfWeek;
             var wDay = new WorkoutDay
             {
                 WorkoutId = workout.Id,
-                DayOfWeek = tDay.DayOfWeek,
-                Name = tDay.DayOfWeek.ToString()
+                DayOfWeek = dow,
+                Name = dow.ToString()
             };
             Db.WorkoutDays.Add(wDay);
             await Db.SaveChangesAsync();
 
-            foreach (var tEx in tDay.Exercises.OrderBy(e => e.OrderInDay))
+            var tDay = template.Days.FirstOrDefault(d => d.DayOfWeek == dow);
+            if (tDay != null)
             {
-                var wEx = new WorkoutDayExercise
+                foreach (var tEx in tDay.Exercises.OrderBy(e => e.OrderInDay))
                 {
-                    WorkoutDayId = wDay.Id,
-                    ExerciseId = tEx.ExerciseId,
-                    OrderInDay = tEx.OrderInDay
-                };
-                Db.WorkoutDayExercises.Add(wEx);
+                    var wEx = new WorkoutDayExercise
+                    {
+                        WorkoutDayId = wDay.Id,
+                        ExerciseId = tEx.ExerciseId,
+                        OrderInDay = tEx.OrderInDay
+                    };
+                    Db.WorkoutDayExercises.Add(wEx);
+                }
+
+                await Db.SaveChangesAsync();
             }
         }
 

--- a/Components/Pages/WorkoutForm.razor
+++ b/Components/Pages/WorkoutForm.razor
@@ -94,6 +94,55 @@
             await Db.SaveChangesAsync();
         }
 
+        await CreateUpcomingWeekAsync(workout);
+
         Navigation.NavigateTo("/workouts");
+    }
+
+    private async Task CreateUpcomingWeekAsync(Workout workout)
+    {
+        WorkoutTemplate? template = null;
+        if (workout.WorkoutTemplateId.HasValue)
+        {
+            template = await Db.WorkoutTemplates
+                .Include(t => t.Days)
+                    .ThenInclude(d => d.Exercises)
+                .FirstOrDefaultAsync(t => t.Id == workout.WorkoutTemplateId.Value);
+        }
+
+        var startDate = workout.StartDate ?? DateTime.Today;
+
+        for (int i = 0; i < 7; i++)
+        {
+            var dow = startDate.AddDays(i).DayOfWeek;
+            var wDay = new WorkoutDay
+            {
+                WorkoutId = workout.Id,
+                DayOfWeek = dow,
+                Name = dow.ToString()
+            };
+            Db.WorkoutDays.Add(wDay);
+            await Db.SaveChangesAsync();
+
+            if (template != null)
+            {
+                var tDay = template.Days.FirstOrDefault(d => d.DayOfWeek == dow);
+                if (tDay != null)
+                {
+                    foreach (var tEx in tDay.Exercises.OrderBy(e => e.OrderInDay))
+                    {
+                        var wEx = new WorkoutDayExercise
+                        {
+                            WorkoutDayId = wDay.Id,
+                            ExerciseId = tEx.ExerciseId,
+                            OrderInDay = tEx.OrderInDay
+                        };
+                        Db.WorkoutDayExercises.Add(wEx);
+                    }
+
+                    await Db.SaveChangesAsync();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- automatically schedule workout days when starting a workout from the dashboard
- create upcoming week for custom workouts too so exercises can be logged immediately

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c9ec6da4832493f577e42b2adc13