### PR TITLE
Enable editing and deleting exercises

### DIFF
--- a/Components/Pages/ExerciseForm.razor
+++ b/Components/Pages/ExerciseForm.razor
@@ -1,28 +1,31 @@
 @page "/exercises/create"
+@page "/exercises/edit/{Id:int}"
+@page "/exercises/delete/{Id:int}"
 @using Swol.Data.Models.Config
+@using Microsoft.EntityFrameworkCore
 @inject Swol.Data.ApplicationDbContext Db
 @inject NavigationManager Navigation
 
-<PageTitle>Add Exercise</PageTitle>
+<PageTitle>@pageTitle</PageTitle>
 
 <div class="max-w-4xl mx-auto p-4 space-y-6">
 
-<h1 class="text-2xl font-bold mb-6">Add Exercise</h1>
+<h1 class="text-2xl font-bold mb-6">@pageTitle</h1>
 
-<EditForm Model="exercise" OnValidSubmit="HandleValidSubmit" FormName="ExerciseCreateForm">
+<EditForm Model="exercise" OnValidSubmit="HandleValidSubmit" FormName="ExerciseForm">
     <DataAnnotationsValidator />
     <ValidationSummary class="mb-4 text-red-600" />
     <div class="mb-4">
         <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
-        <InputText class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="exercise.Name" />
+        <InputText class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="exercise.Name" disabled="@isDeleteMode" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
-        <InputTextArea class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="exercise.Description" />
+        <InputTextArea class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="exercise.Description" disabled="@isDeleteMode" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-gray-700 mb-1">Muscle Groups</label>
-        <select class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" multiple @bind="selectedMuscleGroupIds">
+        <select class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" multiple @bind="selectedMuscleGroupIds" disabled="@isDeleteMode">
             @foreach (var mg in muscleGroups)
             {
                 <option value="@mg.Id">@mg.Name</option>
@@ -30,7 +33,18 @@
         </select>
     </div>
     <div class="flex items-center mt-6">
-        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded shadow">Save</button>
+        @if (!isDeleteMode)
+        {
+            <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded shadow">@(Id.HasValue ? "Save" : "Create")</button>
+            @if (Id.HasValue)
+            {
+                <button type="button" class="ml-3 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded shadow" @onclick="DeleteExercise">Delete</button>
+            }
+        }
+        else
+        {
+            <button type="button" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded shadow" @onclick="DeleteExercise">Delete</button>
+        }
         <a class="ml-3 bg-gray-200 hover:bg-gray-300 text-black font-semibold py-2 px-4 rounded shadow" href="/exercises">Cancel</a>
     </div>
 </EditForm>
@@ -38,25 +52,75 @@
 </div>
 
 @code {
+    [Parameter] public int? Id { get; set; }
+
     private Exercise exercise = new();
     private List<MuscleGroup> muscleGroups = new();
     private List<int> selectedMuscleGroupIds = new();
+    private bool isDeleteMode;
+    private string pageTitle = "Add Exercise";
 
-    protected override void OnInitialized()
+    protected override async Task OnParametersSetAsync()
     {
-        muscleGroups = Db.MuscleGroups.OrderBy(mg => mg.Name).ToList();
+        muscleGroups = await Db.MuscleGroups.OrderBy(mg => mg.Name).ToListAsync();
+
+        var relative = Navigation.ToBaseRelativePath(Navigation.Uri).ToLowerInvariant();
+        isDeleteMode = relative.StartsWith("exercises/delete");
+
+        if (Id.HasValue)
+        {
+            exercise = await Db.Exercises
+                .Include(e => e.ExerciseMuscleGroups)
+                .FirstOrDefaultAsync(e => e.Id == Id.Value) ?? new Exercise();
+
+            selectedMuscleGroupIds = exercise.ExerciseMuscleGroups
+                .Select(emg => emg.MuscleGroupId).ToList();
+
+            pageTitle = isDeleteMode ? "Delete Exercise" : "Edit Exercise";
+        }
+        else
+        {
+            exercise = new Exercise();
+            selectedMuscleGroupIds = new List<int>();
+            pageTitle = "Add Exercise";
+        }
     }
 
     private async Task HandleValidSubmit()
     {
-        Db.Exercises.Add(exercise);
+        if (Id.HasValue)
+            Db.Exercises.Update(exercise);
+        else
+            Db.Exercises.Add(exercise);
+
         await Db.SaveChangesAsync();
-        // Add ExerciseMuscleGroup entries
+
+        var existing = Db.ExerciseMuscleGroups.Where(emg => emg.ExerciseId == exercise.Id);
+        Db.ExerciseMuscleGroups.RemoveRange(existing);
+
         foreach (var mgId in selectedMuscleGroupIds)
         {
             Db.ExerciseMuscleGroups.Add(new ExerciseMuscleGroup { ExerciseId = exercise.Id, MuscleGroupId = mgId });
         }
+
         await Db.SaveChangesAsync();
+        Navigation.NavigateTo("/exercises");
+    }
+
+    private async Task DeleteExercise()
+    {
+        if (!Id.HasValue) return;
+
+        var links = Db.ExerciseMuscleGroups.Where(emg => emg.ExerciseId == Id.Value);
+        Db.ExerciseMuscleGroups.RemoveRange(links);
+
+        var ex = await Db.Exercises.FindAsync(Id.Value);
+        if (ex != null)
+        {
+            Db.Exercises.Remove(ex);
+            await Db.SaveChangesAsync();
+        }
+
         Navigation.NavigateTo("/exercises");
     }
 }


### PR DESCRIPTION
## Summary
- update `ExerciseForm` to support create, edit and delete
- detect delete route and disable fields
- add dynamic page titles and buttons
- include route parameters for edit/delete

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856cbd4cc008324a42f9d201eeefce9