### PR TITLE
Enable workout editing and deletion

### DIFF
--- a/Components/Pages/WorkoutForm.razor
+++ b/Components/Pages/WorkoutForm.razor
@@ -1,15 +1,17 @@
 @page "/workouts/create"
+@page "/workouts/edit/{Id:int}"
+@page "/workouts/delete/{Id:int}"
 @inject Swol.Data.ApplicationDbContext Db
 @inject NavigationManager Navigation
 @using Swol.Data.Models
 @using Swol.Data.Models.Work
 @using Swol.Data.Models.Template
 
-<PageTitle>Add Workout</PageTitle>
+<PageTitle>@pageTitle</PageTitle>
 
 <div class="max-w-4xl mx-auto p-4 space-y-6">
 
-<h1 class="text-2xl font-bold mb-6">Add Workout</h1>
+<h1 class="text-2xl font-bold mb-6">@pageTitle</h1>
 
 <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-6 rounded">
     <strong>What is a Workout?</strong><br />
@@ -31,29 +33,67 @@
     <ValidationSummary class="mb-4 text-red-600" />
     <div class="mb-4">
         <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
-        <InputText class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="workout.Name" />
+        <InputText class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="workout.Name" disabled="@isDeleteMode" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
-        <InputTextArea class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="workout.Description" />
+        <InputTextArea class="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" @bind-Value="workout.Description" disabled="@isDeleteMode" />
     </div>
     <div class="mb-4 flex items-center gap-2">
-        <InputCheckbox id="saveTemplate" @bind-Value="saveAsTemplate" />
+        <InputCheckbox id="saveTemplate" @bind-Value="saveAsTemplate" disabled="@isDeleteMode" />
         <label for="saveTemplate" class="text-sm font-medium text-gray-700">Save as template</label>
     </div>
-    <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded shadow">Save</button>
-    <a class="ml-3 bg-gray-200 hover:bg-gray-300 text-black font-semibold py-2 px-4 rounded shadow" href="/workouts">Cancel</a>
+    <div class="flex items-center mt-6">
+        @if (!isDeleteMode)
+        {
+            <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded shadow">@(Id.HasValue ? "Save" : "Create")</button>
+            @if (Id.HasValue)
+            {
+                <button type="button" class="ml-3 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded shadow" @onclick="DeleteWorkout">Delete</button>
+            }
+        }
+        else
+        {
+            <button type="button" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded shadow" @onclick="DeleteWorkout">Delete</button>
+        }
+        <a class="ml-3 bg-gray-200 hover:bg-gray-300 text-black font-semibold py-2 px-4 rounded shadow" href="/workouts">Cancel</a>
+    </div>
 </EditForm>
 
 </div>
 
 @code {
+    [Parameter] public int? Id { get; set; }
+
     private Workout workout = new();
     private bool saveAsTemplate;
+    private bool isDeleteMode;
+    private string pageTitle = "Add Workout";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var relative = Navigation.ToBaseRelativePath(Navigation.Uri).ToLowerInvariant();
+        isDeleteMode = relative.StartsWith("workouts/delete");
+
+        if (Id.HasValue)
+        {
+            workout = await Db.Workouts.FirstOrDefaultAsync(w => w.Id == Id.Value) ?? new Workout();
+            pageTitle = isDeleteMode ? "Delete Workout" : "Edit Workout";
+        }
+        else
+        {
+            workout = new Workout();
+            pageTitle = "Add Workout";
+        }
+    }
 
     private async Task HandleValidSubmit()
     {
-        Db.Workouts.Add(workout);
+        if (Id.HasValue)
+            Db.Workouts.Update(workout);
+        else
+            Db.Workouts.Add(workout);
+
         await Db.SaveChangesAsync();
 
         if (saveAsTemplate)
@@ -94,7 +134,8 @@
             await Db.SaveChangesAsync();
         }
 
-        await CreateUpcomingWeekAsync(workout);
+        if (!Id.HasValue)
+            await CreateUpcomingWeekAsync(workout);
 
         Navigation.NavigateTo("/workouts");
     }
@@ -144,5 +185,19 @@
                 }
             }
         }
+    }
+
+    private async Task DeleteWorkout()
+    {
+        if (!Id.HasValue) return;
+
+        var workoutToDelete = await Db.Workouts.FindAsync(Id.Value);
+        if (workoutToDelete != null)
+        {
+            Db.Workouts.Remove(workoutToDelete);
+            await Db.SaveChangesAsync();
+        }
+
+        Navigation.NavigateTo("/workouts");
     }
 }


### PR DESCRIPTION
## Summary
- allow `WorkoutForm` to accept an optional `Id`
- load and edit existing workout data
- add delete workflow using the same component
- register edit and delete routes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572cb4bdf48324a67928af7a81c934