### PR TITLE
Add logging to ExerciseForm initialization

### DIFF
--- a/Components/Forms/ExerciseForm.razor
+++ b/Components/Forms/ExerciseForm.razor
@@ -1,7 +1,9 @@
 @using Swol.Data.Models.Config
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.Extensions.Logging
 @inject Swol.Data.ApplicationDbContext Db
 @inject NavigationManager Navigation
+@inject ILogger<ExerciseForm> Logger
 
 <PageTitle>@PageTitle</PageTitle>
 
@@ -51,21 +53,29 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        muscleGroups = await Db.MuscleGroups.OrderBy(mg => mg.Name).ToListAsync();
-
-        if (Id.HasValue)
+        try
         {
-            exercise = await Db.Exercises
-                .Include(e => e.ExerciseMuscleGroups)
-                .FirstOrDefaultAsync(e => e.Id == Id.Value) ?? new Exercise();
+            muscleGroups = await Db.MuscleGroups.OrderBy(mg => mg.Name).ToListAsync();
 
-            selectedMuscleGroupIds = exercise.ExerciseMuscleGroups
-                .Select(emg => emg.MuscleGroupId).ToList();
+            if (Id.HasValue)
+            {
+                exercise = await Db.Exercises
+                    .Include(e => e.ExerciseMuscleGroups)
+                    .FirstOrDefaultAsync(e => e.Id == Id.Value) ?? new Exercise();
+
+                selectedMuscleGroupIds = exercise.ExerciseMuscleGroups
+                    .Select(emg => emg.MuscleGroupId).ToList();
+            }
+            else
+            {
+                exercise = new Exercise();
+                selectedMuscleGroupIds = new List<int>();
+            }
         }
-        else
+        catch (Exception ex)
         {
-            exercise = new Exercise();
-            selectedMuscleGroupIds = new List<int>();
+            Logger.LogError(ex, "Error loading ExerciseForm for Id {Id}", Id);
+            throw;
         }
     }
 


### PR DESCRIPTION
## Summary
- capture exceptions in ExerciseForm's parameter setup so navigation failures are logged

## Testing
- `npm run build:css` *(fails: `postcss: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858348966b48324bb65554c1a15ca5f