### PR TITLE
Revise form actions with icon buttons

### DIFF
--- a/Components/Forms/ExerciseFormComponent.razor
+++ b/Components/Forms/ExerciseFormComponent.razor
@@ -9,7 +9,12 @@
 
 <div class="max-w-4xl mx-auto p-4 space-y-6">
 
-<h1 class="text-2xl font-bold mb-6">@PageTitle</h1>
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">@PageTitle</h1>
+    <button type="submit" form="ExerciseForm" class="text-blue-600 hover:text-blue-800 text-2xl">
+        <i class="bi bi-save"></i>
+    </button>
+</div>
 
 <EditForm Model="exercise" OnValidSubmit="HandleValidSubmit" FormName="ExerciseForm">
     <DataAnnotationsValidator />
@@ -46,12 +51,12 @@
         </div>
     </div>
     <div class="flex items-center mt-6">
-        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded shadow">@(Id.HasValue ? "Save" : "Create")</button>
         @if (Id.HasValue)
         {
-            <button type="button" class="ml-3 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded shadow" @onclick="DeleteExercise">Delete</button>
+            <button type="button" class="text-red-600 text-xl" @onclick="DeleteExercise">
+                <i class="bi bi-trash"></i>
+            </button>
         }
-        <a class="ml-3 bg-gray-200 hover:bg-gray-300 text-black font-semibold py-2 px-4 rounded shadow" href="/exercises">Cancel</a>
     </div>
 </EditForm>
 

--- a/Components/Forms/WorkoutForm.razor
+++ b/Components/Forms/WorkoutForm.razor
@@ -10,7 +10,12 @@
 
 <div class="max-w-4xl mx-auto p-4 space-y-6">
 
-<h1 class="text-2xl font-bold mb-6">@PageTitle</h1>
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">@PageTitle</h1>
+    <button type="submit" form="WorkoutCreateForm" class="text-blue-600 hover:text-blue-800 text-2xl">
+        <i class="bi bi-save"></i>
+    </button>
+</div>
 
 <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-6 rounded">
     <strong>What is a Workout?</strong><br />
@@ -43,12 +48,12 @@
         <label for="saveTemplate" class="text-sm font-medium text-gray-700">Save as template</label>
     </div>
     <div class="flex items-center mt-6">
-        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded shadow">@(Id.HasValue ? "Save" : "Create")</button>
         @if (Id.HasValue)
         {
-            <button type="button" class="ml-3 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded shadow" @onclick="DeleteWorkout">Delete</button>
+            <button type="button" class="text-red-600 text-xl" @onclick="DeleteWorkout">
+                <i class="bi bi-trash"></i>
+            </button>
         }
-        <a class="ml-3 bg-gray-200 hover:bg-gray-300 text-black font-semibold py-2 px-4 rounded shadow" href="/workouts">Cancel</a>
     </div>
 </EditForm>
 

--- a/Components/Forms/WorkoutTemplateFormBase.razor
+++ b/Components/Forms/WorkoutTemplateFormBase.razor
@@ -2,17 +2,16 @@
 @using Microsoft.EntityFrameworkCore
 @using Swol.Enums
 
-<div class="justify-self-start">
-    <button type="submit" form="templateForm" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">@(template.Id > 0 ? "Save" : "Create")</button>
-    @if (template.Id > 0)
-    {
-        <button type="button" class="ml-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition" @onclick="DeleteTemplate">Delete</button>
-    }
-    <a href="/templates" class="ml-2 px-4 py-2 bg-gray-200 text-black rounded hover:bg-gray-300 transition">Cancel</a>
-</div>
-<div class="pt-2">
-    <div>
-        <EditForm Model="template" OnValidSubmit="HandleSubmit" id="templateForm">
+<PageTitle>@PageTitle</PageTitle>
+
+<div class="max-w-4xl mx-auto p-4 space-y-6">
+    <EditForm Model="template" OnValidSubmit="HandleSubmit" id="templateForm">
+        <div class="flex items-center justify-between mb-6">
+            <h1 class="text-2xl font-bold">@PageTitle</h1>
+            <button type="submit" class="text-blue-600 hover:text-blue-800 text-2xl">
+                <i class="bi bi-save"></i>
+            </button>
+        </div>
             <div class="mb-3">
                 <div>
                     <div class="flex flex-wrap gap-4">
@@ -53,6 +52,13 @@
                     }
                 </div>
             </div>
-        </EditForm>
-    </div>
+        <div class="flex items-center mt-6">
+            @if (template.Id > 0)
+            {
+                <button type="button" class="text-red-600 text-xl" @onclick="DeleteTemplate">
+                    <i class="bi bi-trash"></i>
+                </button>
+            }
+        </div>
+    </EditForm>
 </div>

--- a/Components/Forms/WorkoutTemplateFormBase.razor.cs
+++ b/Components/Forms/WorkoutTemplateFormBase.razor.cs
@@ -12,6 +12,8 @@ public partial class WorkoutTemplateFormBase : ComponentBase
     [Inject] public NavigationManager Nav { get; set; } = default!;
     [Parameter] public int? Id { get; set; }
 
+    private string PageTitle => Id.HasValue ? "Edit Template" : "Add Template";
+
     private WorkoutTemplate template = new WorkoutTemplate();
     private List<Exercise> allExercises = new();
     private Dictionary<DayOfWeek, int> newExerciseDayId = new();


### PR DESCRIPTION
## Summary
- replace text Save/Delete/Cancel layout on forms with icon placement
- put floppy-disk save icon next to page title
- convert Delete buttons to trashcan icons and remove Cancel links

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583f482ab08324b1f63cc5b77efc44