### PR TITLE
Add devcontainer and AGENTS guidance

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "dotnet9-codex",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "settings": {},
+  "postCreateCommand": "dotnet --version"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Build
+
+dotnet build Swol.sln
+
+# Test
+
+dotnet test Swol.Tests/Swol.Tests.csproj --no-build
+
+# Style
+
+dotnet format
+
+# Setup
+
+If `dotnet` is missing, run `setup.sh` to install the .NET 9 SDK.
+
+# What I want
+
+- For bug fixes: use `Ask`.
+- To implement features or scripts: use `Code`.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+curl -SL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
+export PATH=$PATH:$HOME/.dotnet
+
+dotnet --info


### PR DESCRIPTION
## Summary
- add AGENTS.md to guide Codex build, test, and formatting
- provide setup script for installing .NET
- include `.devcontainer` with Dockerfile for .NET SDK

## Testing
- `./setup.sh` *(fails: CONNECT tunnel failed)*
- `dotnet build Swol.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584820d70c8324b4ba24e20a11ba77