### PR TITLE
Fix workout creation bug and add workout editor

### DIFF
--- a/Components/Forms/WorkoutForm.razor
+++ b/Components/Forms/WorkoutForm.razor
@@ -5,6 +5,8 @@
 @using Swol.Data.Models
 @using Swol.Data.Models.Work
 @using Swol.Data.Models.Template
+@using Swol.Data.Models.Config
+@using Swol.Enums
 
 <PageTitle>@PageTitle</PageTitle>
 
@@ -47,6 +49,36 @@
         <InputCheckbox id="saveTemplate" @bind-Value="saveAsTemplate" />
         <label for="saveTemplate" class="text-sm font-medium text-gray-700">Save as template</label>
     </div>
+    <div class="mb-3">
+        <div class="flex flex-row gap-2 overflow-x-auto flex-nowrap items-start w-full max-w-screen sm:max-w-[calc(100vw-250px)]">
+            @foreach (var day in workout.Days.OrderBy(d => d.DayOfWeek))
+            {
+                <WorkoutDayCard Day="day"
+                                WorkoutDays="workout.Days"
+                                EditingExercises="editingExercises"
+                                SelectedMuscleGroup="selectedMuscleGroup"
+                                RemoveDay="RemoveDay"
+                                DayOfWeekChanged="OnDayOfWeekChanged"
+                                ExerciseSelected="OnExerciseSelected"
+                                MuscleGroupChanged="OnMuscleGroupChanged"
+                                RemoveSelectedMuscleGroup="RemoveSelectedMuscleGroup"
+                                RemoveExercise="RemoveExerciseFromDay"
+                                StartEditingExercise="StartEditingExercise"
+                                StopEditingExercise="StopEditingExercise"
+                                GetExercisesForDay="GetExercisesForDay" />
+            }
+            @if (workout.Days.Count < 7)
+            {
+                <div class="bg-stone-50 rounded w-[250px] min-w-[250px] max-w-[250px] flex flex-col border border-1 border-gray-400 p-2">
+                    <button type="button"
+                            class="px-2 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition"
+                            @onclick="AddDay">
+                        Add Day
+                    </button>
+                </div>
+            }
+        </div>
+    </div>
     <div class="flex items-center mt-6">
         @if (Id.HasValue)
         {
@@ -64,18 +96,148 @@
 
     private Workout workout = new();
     private bool saveAsTemplate;
+    private List<Exercise> allExercises = new();
+    private Dictionary<DayOfWeek, MuscleGroups?> selectedMuscleGroup = new();
+    private Dictionary<DayOfWeek, int> selectedExerciseId = new();
+    private HashSet<(DayOfWeek, int)> editingExercises = new();
     private string PageTitle => Id.HasValue ? "Edit Workout" : "Add Workout";
 
-    protected override async Task OnParametersSetAsync()
+    protected override async Task OnInitializedAsync()
     {
+        allExercises = await Db.Exercises
+            .Include(e => e.ExerciseMuscleGroups)
+                .ThenInclude(emg => emg.MuscleGroup)
+            .OrderBy(e => e.Name)
+            .ToListAsync();
+
         if (Id.HasValue)
         {
-            workout = await Db.Workouts.FirstOrDefaultAsync(w => w.Id == Id.Value) ?? new Workout();
+            workout = await Db.Workouts
+                .Include(w => w.Days)
+                    .ThenInclude(d => d.Exercises)
+                        .ThenInclude(e => e.Exercise)
+                            .ThenInclude(ex => ex.ExerciseMuscleGroups)
+                                .ThenInclude(emg => emg.MuscleGroup)
+                .FirstOrDefaultAsync(w => w.Id == Id.Value) ?? new Workout();
         }
         else
         {
             workout = new Workout();
+            workout.Days.Add(new WorkoutDay { DayOfWeek = DayOfWeek.Sunday });
+            workout.Days.Add(new WorkoutDay { DayOfWeek = DayOfWeek.Monday });
+            workout.Days.Add(new WorkoutDay { DayOfWeek = DayOfWeek.Tuesday });
+            workout.Days.Add(new WorkoutDay { DayOfWeek = DayOfWeek.Wednesday });
+            workout.Days.Add(new WorkoutDay { DayOfWeek = DayOfWeek.Thursday });
+            workout.Days.Add(new WorkoutDay { DayOfWeek = DayOfWeek.Friday });
+            workout.Days.Add(new WorkoutDay { DayOfWeek = DayOfWeek.Saturday });
         }
+    }
+
+    private void AddDay()
+    {
+        var available = Enum.GetValues<DayOfWeek>().Except(workout.Days.Select(d => d.DayOfWeek)).ToList();
+        if (!available.Any()) return;
+        var day = new WorkoutDay { DayOfWeek = available.First() };
+        workout.Days.Add(day);
+        StateHasChanged();
+    }
+
+    private void RemoveDay(WorkoutDay day)
+    {
+        workout.Days.Remove(day);
+        StateHasChanged();
+    }
+
+    private void OnExerciseSelected(WorkoutDay day, object value, WorkoutDayExercise? editingEx = null)
+    {
+        if (int.TryParse(value?.ToString(), out var exId) && exId > 0)
+        {
+            if (editingEx != null)
+            {
+                var exercise = allExercises.FirstOrDefault(e => e.Id == exId);
+                if (exercise == null) return;
+                editingEx.ExerciseId = exId;
+                editingEx.Exercise = exercise;
+            }
+            else
+            {
+                selectedExerciseId[day.DayOfWeek] = exId;
+                AddExerciseToDay(day);
+                selectedExerciseId[day.DayOfWeek] = 0;
+            }
+            StateHasChanged();
+        }
+    }
+
+    private void AddExerciseToDay(WorkoutDay day)
+    {
+        if (!selectedExerciseId.TryGetValue(day.DayOfWeek, out var exId) || exId == 0) return;
+        if (day.Exercises.Any(e => e.ExerciseId == exId)) return;
+        var exercise = allExercises.FirstOrDefault(e => e.Id == exId);
+        if (exercise == null) return;
+        var ex = new WorkoutDayExercise
+        {
+            ExerciseId = exId,
+            Exercise = exercise,
+            OrderInDay = day.Exercises.Count + 1
+        };
+        day.Exercises.Add(ex);
+
+        selectedMuscleGroup[day.DayOfWeek] = null;
+        selectedExerciseId[day.DayOfWeek] = 0;
+        StateHasChanged();
+    }
+
+    private void OnMuscleGroupChanged(DayOfWeek day, object value)
+    {
+        if (Enum.TryParse<MuscleGroups>(value?.ToString(), out var mg))
+            selectedMuscleGroup[day] = mg;
+        else
+            selectedMuscleGroup[day] = null;
+        selectedExerciseId[day] = 0;
+    }
+
+    private void RemoveSelectedMuscleGroup(DayOfWeek dayOfWeek)
+    {
+        if (selectedMuscleGroup.ContainsKey(dayOfWeek))
+        {
+            selectedMuscleGroup.Remove(dayOfWeek);
+            StateHasChanged();
+        }
+    }
+
+    private void StartEditingExercise(DayOfWeek dayOfWeek, int exerciseId)
+    {
+        editingExercises.Add((dayOfWeek, exerciseId));
+    }
+
+    private void StopEditingExercise(DayOfWeek dayOfWeek, int exerciseId)
+    {
+        editingExercises.Remove((dayOfWeek, exerciseId));
+    }
+
+    private IEnumerable<Exercise> GetExercisesForDay(DayOfWeek dayOfWeek)
+    {
+        if (selectedMuscleGroup.TryGetValue(dayOfWeek, out var mg) && mg != null)
+        {
+            return allExercises.Where(ex => ex.ExerciseMuscleGroups.Any(emg => emg.MuscleGroup.Name == mg.ToString()));
+        }
+        return Enumerable.Empty<Exercise>();
+    }
+
+    private void RemoveExerciseFromDay(WorkoutDay day, WorkoutDayExercise ex)
+    {
+        day.Exercises.Remove(ex);
+        StateHasChanged();
+    }
+
+    private void OnDayOfWeekChanged(WorkoutDay day, object? value)
+    {
+        if (value is null) return;
+        if (!Enum.TryParse<DayOfWeek>(value.ToString(), out var newDayOfWeek)) return;
+        if (workout.Days.Any(d => d != day && d.DayOfWeek == newDayOfWeek)) return;
+        day.DayOfWeek = newDayOfWeek;
+        StateHasChanged();
     }
 
     private async Task HandleValidSubmit()

--- a/Components/Pages/Home.razor.cs
+++ b/Components/Pages/Home.razor.cs
@@ -27,6 +27,17 @@ public partial class Home : ComponentBase
         if (activeTemplate == null)
             return;
 
+        var existingWorkout = await Db.Workouts
+            .FirstOrDefaultAsync(w =>
+                w.WorkoutTemplateId == activeTemplate.Id &&
+                w.StartDate == DateTime.Today);
+
+        if (existingWorkout != null)
+        {
+            Nav.NavigateTo($"/workouts/{existingWorkout.Id}");
+            return;
+        }
+
         var workout = new Workout
         {
             Name = $"{activeTemplate.Name} - {DateTime.Today:yyyy-MM-dd}",
@@ -50,7 +61,7 @@ public partial class Home : ComponentBase
             var dow = startDate.AddDays(i).DayOfWeek;
             var wDay = new WorkoutDay
             {
-                Id = workout.Id,
+                WorkoutId = workout.Id,
                 DayOfWeek = dow,
                 Name = dow.ToString()
             };

--- a/Components/Pages/WorkoutDayCard.razor
+++ b/Components/Pages/WorkoutDayCard.razor
@@ -1,0 +1,48 @@
+@using Swol.Data.Models.Work
+@using Swol.Data.Models.Config
+@using Swol.Enums
+
+<div class="bg-stone-50 rounded w-[250px] min-w-[250px] max-w-[250px] flex flex-col border border-1 border-gray-400">
+    <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200">
+        <InputSelect class="block w-auto text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                     @bind-Value="Day.DayOfWeek"
+                     @onchange="e => DayOfWeekChanged?.Invoke(Day, e.Value)">
+            @foreach (var dow in Enum.GetValues<DayOfWeek>())
+            {
+                if (!WorkoutDays.Any(d => d != Day && d.DayOfWeek == dow))
+                {
+                    <option value="@dow">@dow</option>
+                }
+            }
+        </InputSelect>
+        <button type="button" class="p-1 text-gray-700 hover:text-red-600 transition cursor-pointer" @onclick="() => RemoveDay?.Invoke(Day)">
+            <i class="bi bi-trash"></i>
+        </button>
+    </div>
+    <WorkoutExerciseList Day="Day"
+                         EditingExercises="EditingExercises"
+                         RemoveExercise="RemoveExercise"
+                         StartEditingExercise="StartEditingExercise"
+                         StopEditingExercise="StopEditingExercise"
+                         GetExercisesForDay="GetExercisesForDay"
+                         ExerciseSelected="ExerciseSelected"
+                         SelectedMuscleGroup="SelectedMuscleGroup"
+                         MuscleGroupChanged="MuscleGroupChanged"
+                         RemoveSelectedMuscleGroup="RemoveSelectedMuscleGroup" />
+</div>
+
+@code {
+    [Parameter] public WorkoutDay Day { get; set; } = default!;
+    [Parameter] public ICollection<WorkoutDay> WorkoutDays { get; set; } = new List<WorkoutDay>();
+    [Parameter] public HashSet<(DayOfWeek, int)> EditingExercises { get; set; } = new();
+    [Parameter] public Dictionary<DayOfWeek, MuscleGroups?> SelectedMuscleGroup { get; set; } = new();
+    [Parameter] public Action<WorkoutDay>? RemoveDay { get; set; }
+    [Parameter] public Action<WorkoutDay, object?>? DayOfWeekChanged { get; set; }
+    [Parameter] public Action<WorkoutDay, object, WorkoutDayExercise?>? ExerciseSelected { get; set; }
+    [Parameter] public Action<DayOfWeek, object>? MuscleGroupChanged { get; set; }
+    [Parameter] public Action<DayOfWeek>? RemoveSelectedMuscleGroup { get; set; }
+    [Parameter] public Action<WorkoutDay, WorkoutDayExercise>? RemoveExercise { get; set; }
+    [Parameter] public Action<DayOfWeek, int>? StartEditingExercise { get; set; }
+    [Parameter] public Action<DayOfWeek, int>? StopEditingExercise { get; set; }
+    [Parameter] public Func<DayOfWeek, IEnumerable<Exercise>> GetExercisesForDay { get; set; } = default!;
+}

--- a/Components/Pages/WorkoutExerciseList.razor
+++ b/Components/Pages/WorkoutExerciseList.razor
@@ -1,0 +1,108 @@
+@using Swol.Data.Models.Work
+@using Swol.Data.Models.Config
+@using Swol.Enums
+
+<div class="p-2 flex-1">
+    <div class="mb-2 space-y-1">
+        @foreach (var ex in Day.Exercises)
+        {
+            <div class="mb-2 rounded border border-gray-200">
+                <div class="flex items-center justify-between bg-blue-600 p-1 rounded-t pl-2">
+                    <span class="text-white text-sm font-semibold">
+                        @string.Join(", ", ex.Exercise?.ExerciseMuscleGroups.Select(emg => emg.MuscleGroup.Name) ?? new List<string>())
+                    </span>
+                    <button type="button" class="p-1 text-white hover:text-red-200 transition" @onclick="() => RemoveExercise?.Invoke(Day, ex)">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </div>
+                <div class="px-3 py-2 text-gray-900 text-base">
+                    @if (EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0)))
+                    {
+                        <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                @onchange="async e => await HandleExerciseChange(e, ex)"
+                                @onblur="async () => StopEditingExercise?.Invoke(Day.DayOfWeek, ex.Exercise?.Id ?? 0)">
+                            <option value="0">-- Select Exercise --</option>
+                            @foreach (var exercise in GetExercisesForDay(Day.DayOfWeek))
+                            {
+                                <option value="@exercise.Id" selected="@(exercise.Id == (ex.Exercise?.Id ?? 0))">
+                                    @exercise.Name (@string.Join(", ", exercise.ExerciseMuscleGroups.Select(emg => emg.MuscleGroup.Name)))
+                                </option>
+                            }
+                        </select>
+                    }
+                    else
+                    {
+                        <span class="cursor-pointer hover:underline" @onclick="() => StartEditingExercise?.Invoke(Day.DayOfWeek, ex.Exercise?.Id ?? 0)">
+                            @ex.Exercise?.Name
+                        </span>
+                    }
+                </div>
+            </div>
+        }
+
+        @if (!Day.Exercises.Any() && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var msg) || msg == null))
+        {
+            <div class="text-gray-700">No exercises</div>
+        }
+
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selMg) && selMg != null)
+        {
+            <div class="mb-2 rounded border border-gray-200">
+                <div class="flex items-center justify-between bg-blue-600 p-1 rounded-t pl-2">
+                    <span class="text-white text-sm font-semibold">
+                        @selMg
+                    </span>
+                    <button type="button" class="p-1 text-white hover:text-red-200 transition" title="Remove Muscle Group" @onclick="() => RemoveSelectedMuscleGroup?.Invoke(Day.DayOfWeek)">
+                        <i class="bi bi-x-circle"></i>
+                    </button>
+                </div>
+                <div class="px-3 py-2 text-gray-900 text-base">
+                    <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            @onchange="e => ExerciseSelected?.Invoke(Day, e.Value ?? string.Empty, null)">
+                        <option value="0">-- Select Exercise --</option>
+                        @foreach (var ex in GetExercisesForDay(Day.DayOfWeek))
+                        {
+                            <option value="@ex.Id">@ex.Name (@string.Join(", ", ex.ExerciseMuscleGroups.Select(emg => emg.MuscleGroup.Name)))</option>
+                        }
+                    </select>
+                </div>
+            </div>
+        }
+
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selMg2) || selMg2 == null))
+        {
+            <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    @onchange="e => MuscleGroupChanged?.Invoke(Day.DayOfWeek, e?.Value ?? string.Empty)">
+                <option value="">-- Select Muscle Group --</option>
+                @foreach (var mg in Enum.GetValues<MuscleGroups>())
+                {
+                    <option value="@mg">@mg</option>
+                }
+            </select>
+        }
+        else if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var mg) && mg != null && !GetExercisesForDay(Day.DayOfWeek).Any())
+        {
+            <div class="text-gray-400 mb-2">No exercises for this muscle group.</div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public WorkoutDay Day { get; set; } = default!;
+    [Parameter] public HashSet<(DayOfWeek, int)> EditingExercises { get; set; } = new();
+    [Parameter] public Action<WorkoutDay, WorkoutDayExercise>? RemoveExercise { get; set; }
+    [Parameter] public Action<DayOfWeek, int>? StartEditingExercise { get; set; }
+    [Parameter] public Action<DayOfWeek, int>? StopEditingExercise { get; set; }
+    [Parameter] public Func<DayOfWeek, IEnumerable<Exercise>> GetExercisesForDay { get; set; } = default!;
+    [Parameter] public Action<WorkoutDay, object, WorkoutDayExercise?>? ExerciseSelected { get; set; }
+    [Parameter] public Dictionary<DayOfWeek, MuscleGroups?> SelectedMuscleGroup { get; set; } = new();
+    [Parameter] public Action<DayOfWeek, object>? MuscleGroupChanged { get; set; }
+    [Parameter] public Action<DayOfWeek>? RemoveSelectedMuscleGroup { get; set; }
+
+    private Task HandleExerciseChange(ChangeEventArgs e, WorkoutDayExercise ex)
+    {
+        ExerciseSelected?.Invoke(Day, e.Value ?? string.Empty, ex);
+        StopEditingExercise?.Invoke(Day.DayOfWeek, ex.Exercise?.Id ?? 0);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- stop creating duplicate workouts when starting today's workout
- load workout days correctly when generating workouts
- create `WorkoutDayCard` and `WorkoutExerciseList` components for editing workout days
- extend `WorkoutForm` to edit days and exercises

## Testing
- `dotnet build Swol.sln` *(fails: command not found)*
- `dotnet test Swol.Tests/Swol.Tests.csproj --no-build` *(fails: command not found)*
- `dotnet format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584f957f948324be8748b084542306