### PR TITLE
Add DayOfWeek property to workout days

### DIFF
--- a/Components/Forms/WorkoutFormComponent.razor
+++ b/Components/Forms/WorkoutFormComponent.razor
@@ -58,6 +58,7 @@
                                 SelectedMuscleGroup="selectedMuscleGroup"
                                 RemoveDay="RemoveDay"
                                 LabelChanged="OnLabelChanged"
+                                DayOfWeekChanged="OnDayOfWeekChanged"
                                 ExerciseSelected="OnExerciseSelected"
                                 MuscleGroupChanged="OnMuscleGroupChanged"
                                 RemoveSelectedMuscleGroup="RemoveSelectedMuscleGroup"
@@ -117,9 +118,9 @@
         else
         {
             workout = new Workout();
-            workout.Days.Add(new WorkoutDay { Label = "Day 1", OrderNumber = 1 });
-            workout.Days.Add(new WorkoutDay { Label = "Day 2", OrderNumber = 2 });
-            workout.Days.Add(new WorkoutDay { Label = "Day 3", OrderNumber = 3 });
+            workout.Days.Add(new WorkoutDay { Label = "Day 1", DayOfWeek = DayOfWeek.Monday, OrderNumber = 1 });
+            workout.Days.Add(new WorkoutDay { Label = "Day 2", DayOfWeek = DayOfWeek.Tuesday, OrderNumber = 2 });
+            workout.Days.Add(new WorkoutDay { Label = "Day 3", DayOfWeek = DayOfWeek.Wednesday, OrderNumber = 3 });
         }
     }
 
@@ -130,6 +131,7 @@
         var day = new WorkoutDay
         {
             Label = $"Day {dayCountInWeek}",
+            DayOfWeek = DayOfWeek.Monday,
             WeekNumber = currentWeek,
             OrderNumber = nextOrder
         };
@@ -234,6 +236,14 @@
         StateHasChanged();
     }
 
+    private void OnDayOfWeekChanged(WorkoutDay day, object? value)
+    {
+        if (value is null) return;
+        if (!Enum.TryParse<DayOfWeek>(value.ToString(), out var newDayOfWeek)) return;
+        day.DayOfWeek = newDayOfWeek;
+        StateHasChanged();
+    }
+
     private void ChangeWeek(int delta)
     {
         currentWeek += delta;
@@ -272,10 +282,9 @@
             int dayNumber = 1;
             foreach (var wDay in workout.Days.OrderBy(d => d.OrderNumber))
             {
-                var dow = Enum.TryParse<DayOfWeek>(wDay.Label, out var parsed) ? parsed : DayOfWeek.Sunday;
                 var tDay = new WorkoutTemplateDay
                 {
-                    DayOfWeek = dow,
+                    DayOfWeek = wDay.DayOfWeek,
                     DayNumber = dayNumber++,
                 };
 
@@ -319,35 +328,34 @@
 
         for (int i = 0; i < 7; i++)
         {
+            var templateDay = template?.Days.FirstOrDefault(d => d.DayNumber == i + 1);
+            var dow = templateDay?.DayOfWeek ?? (DayOfWeek)i;
             var wDay = new WorkoutDay
             {
                 WorkoutId = workout.Id,
-                Label = $"Day {i + 1}",
+                DayOfWeek = dow,
+                Label = dow.ToString(),
                 WeekNumber = 1,
                 OrderNumber = i + 1,
-                Name = $"Day {i + 1}"
+                Name = dow.ToString()
             };
             Db.WorkoutDays.Add(wDay);
             await Db.SaveChangesAsync();
 
-            if (template != null)
+            if (templateDay != null)
             {
-                var tDay = template.Days.FirstOrDefault(d => d.DayNumber == i + 1);
-                if (tDay != null)
+                foreach (var tEx in templateDay.Exercises.OrderBy(e => e.OrderInDay))
                 {
-                    foreach (var tEx in tDay.Exercises.OrderBy(e => e.OrderInDay))
+                    var wEx = new WorkoutDayExercise
                     {
-                        var wEx = new WorkoutDayExercise
-                        {
-                            WorkoutDayId = wDay.Id,
-                            ExerciseId = tEx.ExerciseId,
-                            OrderInDay = tEx.OrderInDay
-                        };
-                        Db.WorkoutDayExercises.Add(wEx);
-                    }
-
-                    await Db.SaveChangesAsync();
+                        WorkoutDayId = wDay.Id,
+                        ExerciseId = tEx.ExerciseId,
+                        OrderInDay = tEx.OrderInDay
+                    };
+                    Db.WorkoutDayExercises.Add(wEx);
                 }
+
+                await Db.SaveChangesAsync();
             }
         }
     }

--- a/Components/Pages/Home.razor.cs
+++ b/Components/Pages/Home.razor.cs
@@ -61,10 +61,11 @@ public partial class Home : ComponentBase
             var wDay = new WorkoutDay
             {
                 WorkoutId = workout.Id,
-                Label = $"Day {tDay.DayNumber}",
+                DayOfWeek = tDay.DayOfWeek,
+                Label = tDay.DayOfWeek.ToString(),
                 WeekNumber = weekNumber,
                 OrderNumber = orderNumber++,
-                Name = $"Day {tDay.DayNumber}"
+                Name = tDay.DayOfWeek.ToString()
             };
             Db.WorkoutDays.Add(wDay);
             await Db.SaveChangesAsync();

--- a/Components/Pages/WorkoutDayCard.razor
+++ b/Components/Pages/WorkoutDayCard.razor
@@ -4,9 +4,19 @@
 
 <div class="bg-stone-50 rounded w-[250px] min-w-[250px] max-w-[250px] flex flex-col border border-1 border-gray-400">
     <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200">
-        <InputText class="block w-auto text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                   @bind-Value="Day.Label"
-                   @onchange="e => LabelChanged?.Invoke(Day, e.Value)" />
+        <div class="flex gap-2">
+            <InputSelect class="block w-auto text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                         @bind-Value="Day.DayOfWeek"
+                         @onchange="e => DayOfWeekChanged?.Invoke(Day, e.Value)">
+                @foreach (var dow in Enum.GetValues<DayOfWeek>())
+                {
+                    <option value="@dow">@dow</option>
+                }
+            </InputSelect>
+            <InputText class="block w-auto text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                       @bind-Value="Day.Label"
+                       @onchange="e => LabelChanged?.Invoke(Day, e.Value)" />
+        </div>
         <button type="button" class="p-1 text-gray-700 hover:text-red-600 transition cursor-pointer" @onclick="() => RemoveDay?.Invoke(Day)">
             <i class="bi bi-trash"></i>
         </button>
@@ -30,6 +40,7 @@
     [Parameter] public Dictionary<string, MuscleGroups?> SelectedMuscleGroup { get; set; } = new();
     [Parameter] public Action<WorkoutDay>? RemoveDay { get; set; }
     [Parameter] public Action<WorkoutDay, object?>? LabelChanged { get; set; }
+    [Parameter] public Action<WorkoutDay, object?>? DayOfWeekChanged { get; set; }
     [Parameter] public Action<WorkoutDay, object, WorkoutDayExercise?>? ExerciseSelected { get; set; }
     [Parameter] public Action<string, object>? MuscleGroupChanged { get; set; }
     [Parameter] public Action<string>? RemoveSelectedMuscleGroup { get; set; }

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -67,6 +67,9 @@ public class ApplicationDbContext : DbContext
             .WithMany(w => w.Days)
             .HasForeignKey(wd => wd.WorkoutId);
         modelBuilder.Entity<WorkoutDay>()
+            .Property(wd => wd.DayOfWeek)
+            .IsRequired();
+        modelBuilder.Entity<WorkoutDay>()
             .Property(wd => wd.Label)
             .IsRequired();
         modelBuilder.Entity<WorkoutDay>()

--- a/Data/Models/Work/WorkoutDay.cs
+++ b/Data/Models/Work/WorkoutDay.cs
@@ -5,6 +5,7 @@ public class WorkoutDay
     public int Id { get; set; }
     public int WorkoutId { get; set; }
     public Workout Workout { get; set; } = null!;
+    public DayOfWeek DayOfWeek { get; set; }
     public string Label { get; set; } = string.Empty;
     public int WeekNumber { get; set; } = 1;
     public int OrderNumber { get; set; }


### PR DESCRIPTION
## Summary
- include DayOfWeek in WorkoutDay model
- require DayOfWeek in ApplicationDbContext configuration
- allow selecting day of week and label on workout day cards
- adapt workout form and startup logic to use DayOfWeek

## Testing
- `dotnet build Swol.sln` *(fails: command not found)*
- `dotnet test Swol.Tests/Swol.Tests.csproj --no-build` *(fails: command not found)*
- `dotnet format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685868d568948324b85a595080f8bffc