### PR TITLE
Rename shorthand variables

### DIFF
--- a/Components/Forms/ExerciseFormComponent.razor
+++ b/Components/Forms/ExerciseFormComponent.razor
@@ -42,18 +42,18 @@
                 <div class="flex-1">
                     <h3 class="text-sm font-semibold mb-2">Selected</h3>
                     <div class="flex flex-wrap gap-2">
-                        @foreach (var mg in muscleGroups.Where(mg => selectedMuscleGroupIds.Contains(mg.Id)))
+                        @foreach (var group in muscleGroups.Where(mg => selectedMuscleGroupIds.Contains(mg.Id)))
                         {
-                            <button type="button" class="px-3 py-2 bg-blue-600 text-white rounded" @onclick="() => RemoveMuscleGroup(mg.Id)">@mg.Name</button>
+                            <button type="button" class="px-3 py-2 bg-blue-600 text-white rounded" @onclick="() => RemoveMuscleGroup(group.Id)">@group.Name</button>
                         }
                     </div>
                 </div>
                 <div class="flex-1">
                     <h3 class="text-sm font-semibold mb-2">Available</h3>
                     <div class="flex flex-wrap gap-2">
-                        @foreach (var mg in muscleGroups.Where(mg => !selectedMuscleGroupIds.Contains(mg.Id)))
+                        @foreach (var group in muscleGroups.Where(mg => !selectedMuscleGroupIds.Contains(mg.Id)))
                         {
-                            <button type="button" class="px-3 py-2 bg-gray-200 text-black rounded" @onclick="() => AddMuscleGroup(mg.Id)">@mg.Name</button>
+                            <button type="button" class="px-3 py-2 bg-gray-200 text-black rounded" @onclick="() => AddMuscleGroup(group.Id)">@group.Name</button>
                         }
                     </div>
                 </div>
@@ -125,9 +125,9 @@
         var existing = Db.ExerciseMuscleGroups.Where(emg => emg.ExerciseId == exercise.Id);
         Db.ExerciseMuscleGroups.RemoveRange(existing);
 
-        foreach (var mgId in selectedMuscleGroupIds)
+        foreach (var muscleGroupId in selectedMuscleGroupIds)
         {
-            Db.ExerciseMuscleGroups.Add(new ExerciseMuscleGroup { ExerciseId = exercise.Id, MuscleGroupId = mgId });
+            Db.ExerciseMuscleGroups.Add(new ExerciseMuscleGroup { ExerciseId = exercise.Id, MuscleGroupId = muscleGroupId });
         }
 
         await Db.SaveChangesAsync();

--- a/Components/Forms/WorkoutFormComponent.razor
+++ b/Components/Forms/WorkoutFormComponent.razor
@@ -188,8 +188,8 @@
 
     private void OnMuscleGroupChanged(string day, object value)
     {
-        if (Enum.TryParse<MuscleGroups>(value?.ToString(), out var mg))
-            selectedMuscleGroup[day] = mg;
+        if (Enum.TryParse<MuscleGroups>(value?.ToString(), out var muscleGroup))
+            selectedMuscleGroup[day] = muscleGroup;
         else
             selectedMuscleGroup[day] = null;
         selectedExerciseId[day] = 0;
@@ -216,9 +216,9 @@
 
     private IEnumerable<Exercise> GetExercisesForDay(string label)
     {
-        if (selectedMuscleGroup.TryGetValue(label, out var mg) && mg != null)
+        if (selectedMuscleGroup.TryGetValue(label, out var muscleGroup) && muscleGroup != null)
         {
-            return allExercises.Where(ex => ex.ExerciseMuscleGroups.Any(emg => emg.MuscleGroup.Name == mg.ToString()));
+            return allExercises.Where(ex => ex.ExerciseMuscleGroups.Any(emg => emg.MuscleGroup.Name == muscleGroup.ToString()));
         }
         return Enumerable.Empty<Exercise>();
     }
@@ -280,25 +280,25 @@
             };
 
             int dayNumber = 1;
-            foreach (var wDay in workout.Days.OrderBy(d => d.OrderNumber))
+            foreach (var workoutDay in workout.Days.OrderBy(d => d.OrderNumber))
             {
-                var tDay = new WorkoutTemplateDay
+                var templateDay = new WorkoutTemplateDay
                 {
-                    DayOfWeek = wDay.DayOfWeek,
+                    DayOfWeek = workoutDay.DayOfWeek,
                     DayNumber = dayNumber++,
                 };
 
-                foreach (var wEx in wDay.Exercises.OrderBy(e => e.OrderInDay))
+                foreach (var workoutExercise in workoutDay.Exercises.OrderBy(e => e.OrderInDay))
                 {
-                    var tEx = new WorkoutTemplateDayExercise
+                    var templateExercise = new WorkoutTemplateDayExercise
                     {
-                        ExerciseId = wEx.ExerciseId,
-                        OrderInDay = wEx.OrderInDay
+                        ExerciseId = workoutExercise.ExerciseId,
+                        OrderInDay = workoutExercise.OrderInDay
                     };
-                    tDay.Exercises.Add(tEx);
+                    templateDay.Exercises.Add(templateExercise);
                 }
 
-                template.Days.Add(tDay);
+                template.Days.Add(templateDay);
             }
 
             Db.WorkoutTemplates.Add(template);
@@ -330,7 +330,7 @@
         {
             var templateDay = template?.Days.FirstOrDefault(d => d.DayNumber == i + 1);
             var dow = templateDay?.DayOfWeek ?? (DayOfWeek)i;
-            var wDay = new WorkoutDay
+            var workoutDay = new WorkoutDay
             {
                 WorkoutId = workout.Id,
                 DayOfWeek = dow,
@@ -339,20 +339,20 @@
                 OrderNumber = i + 1,
                 Name = dow.ToString()
             };
-            Db.WorkoutDays.Add(wDay);
+            Db.WorkoutDays.Add(workoutDay);
             await Db.SaveChangesAsync();
 
             if (templateDay != null)
             {
-                foreach (var tEx in templateDay.Exercises.OrderBy(e => e.OrderInDay))
+                foreach (var templateExercise in templateDay.Exercises.OrderBy(e => e.OrderInDay))
                 {
-                    var wEx = new WorkoutDayExercise
+                    var workoutExercise = new WorkoutDayExercise
                     {
-                        WorkoutDayId = wDay.Id,
-                        ExerciseId = tEx.ExerciseId,
-                        OrderInDay = tEx.OrderInDay
+                        WorkoutDayId = workoutDay.Id,
+                        ExerciseId = templateExercise.ExerciseId,
+                        OrderInDay = templateExercise.OrderInDay
                     };
-                    Db.WorkoutDayExercises.Add(wEx);
+                    Db.WorkoutDayExercises.Add(workoutExercise);
                 }
 
                 await Db.SaveChangesAsync();

--- a/Components/Forms/WorkoutTemplateFormBase.razor.cs
+++ b/Components/Forms/WorkoutTemplateFormBase.razor.cs
@@ -120,8 +120,8 @@ public partial class WorkoutTemplateFormBase : ComponentBase
 
     private void OnMuscleGroupChanged(DayOfWeek day, object value)
     {
-        if (Enum.TryParse<MuscleGroups>(value?.ToString(), out var mg))
-            selectedMuscleGroup[day] = mg;
+        if (Enum.TryParse<MuscleGroups>(value?.ToString(), out var muscleGroup))
+            selectedMuscleGroup[day] = muscleGroup;
         else
             selectedMuscleGroup[day] = null;
         selectedExerciseId[day] = 0;
@@ -142,9 +142,9 @@ public partial class WorkoutTemplateFormBase : ComponentBase
 
         if (ex?.Exercise != null)
         {
-            var mg = ex.Exercise.ExerciseMuscleGroups.FirstOrDefault()?.MuscleGroup;
-            if (mg != null)
-                editingMuscleGroup[(dayOfWeek, exerciseId)] = Enum.Parse<MuscleGroups>(mg.Name);
+            var muscleGroup = ex.Exercise.ExerciseMuscleGroups.FirstOrDefault()?.MuscleGroup;
+            if (muscleGroup != null)
+                editingMuscleGroup[(dayOfWeek, exerciseId)] = Enum.Parse<MuscleGroups>(muscleGroup.Name);
         }
     }
     private void StopEditingExercise(DayOfWeek dayOfWeek, int exerciseId)
@@ -154,9 +154,9 @@ public partial class WorkoutTemplateFormBase : ComponentBase
     }
     private IEnumerable<Exercise> GetExercisesForDay(DayOfWeek dayOfWeek)
     {
-        if (selectedMuscleGroup.TryGetValue(dayOfWeek, out var mg) && mg != null)
+        if (selectedMuscleGroup.TryGetValue(dayOfWeek, out var muscleGroup) && muscleGroup != null)
         {
-            return allExercises.Where(ex => ex.ExerciseMuscleGroups.Any(emg => emg.MuscleGroup.Name == mg.ToString()));
+            return allExercises.Where(ex => ex.ExerciseMuscleGroups.Any(emg => emg.MuscleGroup.Name == muscleGroup.ToString()));
         }
         return Enumerable.Empty<Exercise>();
     }

--- a/Components/Pages/Home.razor.cs
+++ b/Components/Pages/Home.razor.cs
@@ -56,31 +56,31 @@ public partial class Home : ComponentBase
 
         int weekNumber = 1;
         int orderNumber = 1;
-        foreach (var tDay in template.Days.OrderBy(d => d.DayNumber))
+        foreach (var templateDay in template.Days.OrderBy(d => d.DayNumber))
         {
-            var wDay = new WorkoutDay
+            var workoutDay = new WorkoutDay
             {
                 WorkoutId = workout.Id,
-                DayOfWeek = tDay.DayOfWeek,
-                Label = tDay.DayOfWeek.ToString(),
+                DayOfWeek = templateDay.DayOfWeek,
+                Label = templateDay.DayOfWeek.ToString(),
                 WeekNumber = weekNumber,
                 OrderNumber = orderNumber++,
-                Name = tDay.DayOfWeek.ToString()
+                Name = templateDay.DayOfWeek.ToString()
             };
-            Db.WorkoutDays.Add(wDay);
+            Db.WorkoutDays.Add(workoutDay);
             await Db.SaveChangesAsync();
 
-            if (tDay != null)
+            if (templateDay != null)
             {
-                foreach (var tEx in tDay.Exercises.OrderBy(e => e.OrderInDay))
+                foreach (var templateExercise in templateDay.Exercises.OrderBy(e => e.OrderInDay))
                 {
-                    var wEx = new WorkoutDayExercise
+                    var workoutExercise = new WorkoutDayExercise
                     {
-                        WorkoutDayId = wDay.Id,
-                        ExerciseId = tEx.ExerciseId,
-                        OrderInDay = tEx.OrderInDay
+                        WorkoutDayId = workoutDay.Id,
+                        ExerciseId = templateExercise.ExerciseId,
+                        OrderInDay = templateExercise.OrderInDay
                     };
-                    Db.WorkoutDayExercises.Add(wEx);
+                    Db.WorkoutDayExercises.Add(workoutExercise);
                 }
             }
 

--- a/Components/Pages/MuscleGroupList.razor
+++ b/Components/Pages/MuscleGroupList.razor
@@ -25,12 +25,12 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach (var mg in groups)
+                    @foreach (var group in groups)
                     {
                         <tr class="border-t border-gray-200 hover:bg-gray-50">
-                            <td class="px-4 py-2">@mg.Name</td>
+                            <td class="px-4 py-2">@group.Name</td>
                             <td class="px-4 py-2 whitespace-nowrap">
-                                <a class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-1 px-3 rounded shadow text-sm mr-2" href="/musclegroups/form/@mg.Id">Edit</a>
+                                <a class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-1 px-3 rounded shadow text-sm mr-2" href="/musclegroups/form/@group.Id">Edit</a>
                             </td>
                         </tr>
                     }

--- a/Components/Pages/WorkoutExerciseList.razor
+++ b/Components/Pages/WorkoutExerciseList.razor
@@ -40,17 +40,17 @@
             </div>
         }
 
-        @if (!Day.Exercises.Any() && (!SelectedMuscleGroup.TryGetValue(Day.Label, out var msg) || msg == null))
+        @if (!Day.Exercises.Any() && (!SelectedMuscleGroup.TryGetValue(Day.Label, out var group) || group == null))
         {
             <div class="text-gray-700">No exercises</div>
         }
 
-        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.Label, out var selMg) && selMg != null)
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.Label, out var selectedGroup) && selectedGroup != null)
         {
             <div class="mb-2 rounded border border-gray-200">
                 <div class="flex items-center justify-between bg-blue-600 p-1 rounded-t pl-2">
                     <span class="text-white text-sm font-semibold">
-                        @selMg
+                        @selectedGroup
                     </span>
                     <button type="button" class="p-1 text-white hover:text-red-200 transition" title="Remove Muscle Group" @onclick="() => RemoveSelectedMuscleGroup?.Invoke(Day.Label)">
                         <i class="bi bi-x-circle"></i>
@@ -69,18 +69,18 @@
             </div>
         }
 
-        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && (!SelectedMuscleGroup.TryGetValue(Day.Label, out var selMg2) || selMg2 == null))
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && (!SelectedMuscleGroup.TryGetValue(Day.Label, out var selectedGroup2) || selectedGroup2 == null))
         {
             <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     @onchange="e => MuscleGroupChanged?.Invoke(Day.Label, e?.Value ?? string.Empty)">
                 <option value="">-- Select Muscle Group --</option>
-                @foreach (var mg in Enum.GetValues<MuscleGroups>())
+                @foreach (var group in Enum.GetValues<MuscleGroups>())
                 {
-                    <option value="@mg">@mg</option>
+                    <option value="@group">@group</option>
                 }
             </select>
         }
-        else if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.Label, out var mg) && mg != null && !GetExercisesForDay(Day.Label).Any())
+        else if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.Label, out var muscleGroup) && muscleGroup != null && !GetExercisesForDay(Day.Label).Any())
         {
             <div class="text-gray-400 mb-2">No exercises for this muscle group.</div>
         }

--- a/Components/Pages/WorkoutTemplateExerciseList.razor
+++ b/Components/Pages/WorkoutTemplateExerciseList.razor
@@ -40,17 +40,17 @@
             </div>
         }
 
-        @if (!Day.Exercises.Any() && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var msg) || msg == null))
+        @if (!Day.Exercises.Any() && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var group) || group == null))
         {
             <div class="text-gray-700">No exercises</div>
         }
 
-        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selMg) && selMg != null)
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selectedGroup) && selectedGroup != null)
         {
             <div class="mb-2 rounded border border-gray-200">
                 <div class="flex items-center justify-between bg-blue-600 p-1 rounded-t pl-2">
                     <span class="text-white text-sm font-semibold">
-                        @selMg
+                        @selectedGroup
                     </span>
                     <button type="button" class="p-1 text-white hover:text-red-200 transition" title="Remove Muscle Group" @onclick="() => RemoveSelectedMuscleGroup?.Invoke(Day.DayOfWeek)">
                         <i class="bi bi-x-circle"></i>
@@ -71,18 +71,18 @@
             </div>
         }
 
-        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selMg2) || selMg2 == null))
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selectedGroup2) || selectedGroup2 == null))
         {
             <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     @onchange="e => MuscleGroupChanged?.Invoke(Day.DayOfWeek, e?.Value ?? string.Empty)">
                 <option value="">-- Select Muscle Group --</option>
-                @foreach (var mg in Enum.GetValues<MuscleGroups>())
+                @foreach (var group in Enum.GetValues<MuscleGroups>())
                 {
-                    <option value="@mg">@mg</option>
+                    <option value="@group">@group</option>
                 }
             </select>
         }
-        else if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var mg) && mg != null && !GetExercisesForDay(Day.DayOfWeek).Any())
+        else if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var muscleGroup) && muscleGroup != null && !GetExercisesForDay(Day.DayOfWeek).Any())
         {
             <div class="text-gray-400 mb-2">No exercises for this muscle group.</div>
         }


### PR DESCRIPTION
## Summary
- rename workout/shorthand variables to descriptive names
- update variable names in Home page
- adjust muscle group component code

## Testing
- `dotnet format` *(fails: `dotnet` not found)*
- `dotnet build Swol.sln` *(fails: `dotnet` not found)*
- `dotnet test Swol.Tests/Swol.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586bd96328832496c3cc165269e26a