### PR TITLE
Enable custom ordering and labeling for template days

### DIFF
--- a/Components/Forms/WorkoutFormComponent.razor
+++ b/Components/Forms/WorkoutFormComponent.razor
@@ -279,13 +279,13 @@
                 CreatedOn = DateTime.UtcNow
             };
 
-            int dayNumber = 1;
             foreach (var workoutDay in workout.Days.OrderBy(d => d.OrderNumber))
             {
                 var templateDay = new WorkoutTemplateDay
                 {
                     DayOfWeek = workoutDay.DayOfWeek,
-                    DayNumber = dayNumber++,
+                    Label = workoutDay.Label,
+                    OrderNumber = workoutDay.OrderNumber,
                 };
 
                 foreach (var workoutExercise in workoutDay.Exercises.OrderBy(e => e.OrderInDay))
@@ -328,16 +328,16 @@
 
         for (int i = 0; i < 7; i++)
         {
-            var templateDay = template?.Days.FirstOrDefault(d => d.DayNumber == i + 1);
+            var templateDay = template?.Days.FirstOrDefault(d => d.OrderNumber == i + 1);
             var dow = templateDay?.DayOfWeek ?? (DayOfWeek)i;
             var workoutDay = new WorkoutDay
             {
                 WorkoutId = workout.Id,
                 DayOfWeek = dow,
-                Label = dow.ToString(),
+                Label = templateDay?.Label ?? dow.ToString(),
                 WeekNumber = 1,
                 OrderNumber = i + 1,
-                Name = dow.ToString()
+                Name = templateDay?.Label ?? dow.ToString()
             };
             Db.WorkoutDays.Add(workoutDay);
             await Db.SaveChangesAsync();

--- a/Components/Forms/WorkoutTemplateFormBase.razor
+++ b/Components/Forms/WorkoutTemplateFormBase.razor
@@ -32,13 +32,14 @@
             </div>
             <div class="mb-3">
                 <div class="flex flex-row gap-2 overflow-x-auto flex-nowrap items-start w-full max-w-screen sm:max-w-[calc(100vw-250px)]">
-                    @foreach (var day in template.Days.OrderBy(d => d.DayOfWeek))
+                    @foreach (var day in template.Days.OrderBy(d => d.OrderNumber))
                     {
                         <WorkoutTemplateDayCard Day="day"
                                                 TemplateDays="template.Days"
                                                 EditingExercises="editingExercises"
                                                 SelectedMuscleGroup="selectedMuscleGroup"
                                                 RemoveDay="RemoveDay"
+                                                LabelChanged="OnLabelChanged"
                                                 DayOfWeekChanged="OnDayOfWeekChanged"
                                                 ExerciseSelected="OnExerciseSelected"
                                                 MuscleGroupChanged="OnMuscleGroupChanged"

--- a/Components/Pages/Home.razor.cs
+++ b/Components/Pages/Home.razor.cs
@@ -56,16 +56,16 @@ public partial class Home : ComponentBase
 
         int weekNumber = 1;
         int orderNumber = 1;
-        foreach (var templateDay in template.Days.OrderBy(d => d.DayNumber))
+        foreach (var templateDay in template.Days.OrderBy(d => d.OrderNumber))
         {
             var workoutDay = new WorkoutDay
             {
                 WorkoutId = workout.Id,
                 DayOfWeek = templateDay.DayOfWeek,
-                Label = templateDay.DayOfWeek.ToString(),
+                Label = templateDay.Label,
                 WeekNumber = weekNumber,
                 OrderNumber = orderNumber++,
-                Name = templateDay.DayOfWeek.ToString()
+                Name = templateDay.Label
             };
             Db.WorkoutDays.Add(workoutDay);
             await Db.SaveChangesAsync();

--- a/Components/Pages/WorkoutTemplateDayCard.razor
+++ b/Components/Pages/WorkoutTemplateDayCard.razor
@@ -4,17 +4,19 @@
 
 <div class="bg-stone-50 rounded w-[250px] min-w-[250px] max-w-[250px] flex flex-col border border-1 border-gray-400">
     <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200">
-        <InputSelect class="block w-auto text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                     @bind-Value="Day.DayOfWeek"
-                     @onchange="e => DayOfWeekChanged?.Invoke(Day, e.Value)">
-            @foreach (var dow in Enum.GetValues<DayOfWeek>())
-            {
-                if (!TemplateDays.Any(d => d != Day && d.DayOfWeek == dow))
+        <div class="flex gap-2">
+            <InputSelect class="block w-auto text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                         @bind-Value="Day.DayOfWeek"
+                         @onchange="e => DayOfWeekChanged?.Invoke(Day, e.Value)">
+                @foreach (var dow in Enum.GetValues<DayOfWeek>())
                 {
                     <option value="@dow">@dow</option>
                 }
-            }
-        </InputSelect>
+            </InputSelect>
+            <InputText class="block w-auto text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                       @bind-Value="Day.Label"
+                       @onchange="e => LabelChanged?.Invoke(Day, e.Value)" />
+        </div>
         <button type="button" class="p-1 text-gray-700 hover:text-red-600 transition cursor-pointer" @onclick="() => RemoveDay?.Invoke(Day)">
             <i class="bi bi-trash"></i>
         </button>
@@ -34,15 +36,16 @@
 @code {
     [Parameter] public WorkoutTemplateDay Day { get; set; } = default!;
     [Parameter] public ICollection<WorkoutTemplateDay> TemplateDays { get; set; } = new List<WorkoutTemplateDay>();
-    [Parameter] public HashSet<(DayOfWeek, int)> EditingExercises { get; set; } = new();
-    [Parameter] public Dictionary<DayOfWeek, MuscleGroups?> SelectedMuscleGroup { get; set; } = new();
+    [Parameter] public HashSet<(string, int)> EditingExercises { get; set; } = new();
+    [Parameter] public Dictionary<string, MuscleGroups?> SelectedMuscleGroup { get; set; } = new();
     [Parameter] public Action<WorkoutTemplateDay>? RemoveDay { get; set; }
+    [Parameter] public Action<WorkoutTemplateDay, object?>? LabelChanged { get; set; }
     [Parameter] public Action<WorkoutTemplateDay, object?>? DayOfWeekChanged { get; set; }
     [Parameter] public Action<WorkoutTemplateDay, object, WorkoutTemplateDayExercise?>? ExerciseSelected { get; set; }
-    [Parameter] public Action<DayOfWeek, object>? MuscleGroupChanged { get; set; }
-    [Parameter] public Action<DayOfWeek>? RemoveSelectedMuscleGroup { get; set; }
+    [Parameter] public Action<string, object>? MuscleGroupChanged { get; set; }
+    [Parameter] public Action<string>? RemoveSelectedMuscleGroup { get; set; }
     [Parameter] public Action<WorkoutTemplateDay, WorkoutTemplateDayExercise>? RemoveExercise { get; set; }
-    [Parameter] public Action<DayOfWeek, int>? StartEditingExercise { get; set; }
-    [Parameter] public Action<DayOfWeek, int>? StopEditingExercise { get; set; }
-    [Parameter] public Func<DayOfWeek, IEnumerable<Exercise>> GetExercisesForDay { get; set; } = default!;
+    [Parameter] public Action<string, int>? StartEditingExercise { get; set; }
+    [Parameter] public Action<string, int>? StopEditingExercise { get; set; }
+    [Parameter] public Func<string, IEnumerable<Exercise>> GetExercisesForDay { get; set; } = default!;
 }

--- a/Components/Pages/WorkoutTemplateExerciseList.razor
+++ b/Components/Pages/WorkoutTemplateExerciseList.razor
@@ -16,13 +16,13 @@
                     </button>
                 </div>
                 <div class="px-3 py-2 text-gray-900 text-base">
-                    @if (EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0)))
+                    @if (EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0)))
                     {
                         <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
                                 @onchange="async e => await HandleExerciseChange(e, ex)"
-                                @onblur="async () => StopEditingExercise?.Invoke(Day.DayOfWeek, ex.Exercise?.Id ?? 0)">
+                                @onblur="async () => StopEditingExercise?.Invoke(Day.Label, ex.Exercise?.Id ?? 0)">
                             <option value="0">-- Select Exercise --</option>
-                            @foreach (var exercise in GetExercisesForDay(Day.DayOfWeek))
+                            @foreach (var exercise in GetExercisesForDay(Day.Label))
                             {
                                 <option value="@exercise.Id" selected="@(exercise.Id == (ex.Exercise?.Id ?? 0))">
                                     @exercise.Name (@string.Join(", ", exercise.ExerciseMuscleGroups.Select(emg => emg.MuscleGroup.Name)))
@@ -32,7 +32,7 @@
                     }
                     else
                     {
-                        <span class="cursor-pointer hover:underline" @onclick="() => StartEditingExercise?.Invoke(Day.DayOfWeek, ex.Exercise?.Id ?? 0)">
+                        <span class="cursor-pointer hover:underline" @onclick="() => StartEditingExercise?.Invoke(Day.Label, ex.Exercise?.Id ?? 0)">
                             @ex.Exercise?.Name
                         </span>
                     }
@@ -40,19 +40,19 @@
             </div>
         }
 
-        @if (!Day.Exercises.Any() && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var group) || group == null))
+        @if (!Day.Exercises.Any() && (!SelectedMuscleGroup.TryGetValue(Day.Label, out var group) || group == null))
         {
             <div class="text-gray-700">No exercises</div>
         }
 
-        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selectedGroup) && selectedGroup != null)
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.Label, out var selectedGroup) && selectedGroup != null)
         {
             <div class="mb-2 rounded border border-gray-200">
                 <div class="flex items-center justify-between bg-blue-600 p-1 rounded-t pl-2">
                     <span class="text-white text-sm font-semibold">
                         @selectedGroup
                     </span>
-                    <button type="button" class="p-1 text-white hover:text-red-200 transition" title="Remove Muscle Group" @onclick="() => RemoveSelectedMuscleGroup?.Invoke(Day.DayOfWeek)">
+                    <button type="button" class="p-1 text-white hover:text-red-200 transition" title="Remove Muscle Group" @onclick="() => RemoveSelectedMuscleGroup?.Invoke(Day.Label)">
                         <i class="bi bi-x-circle"></i>
                     </button>
                 </div>
@@ -60,7 +60,7 @@
                     <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
                             @onchange="e => ExerciseSelected?.Invoke(Day, e.Value ?? string.Empty, null)">
                         <option value="0">-- Select Exercise --</option>
-                        @foreach (var ex in GetExercisesForDay(Day.DayOfWeek))
+                        @foreach (var ex in GetExercisesForDay(Day.Label))
                         {
                             <option value="@ex.Id">
                                 @ex.Name (@string.Join(", ", ex.ExerciseMuscleGroups.Select(emg => emg.MuscleGroup.Name)))
@@ -71,10 +71,10 @@
             </div>
         }
 
-        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && (!SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var selectedGroup2) || selectedGroup2 == null))
+        @if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && (!SelectedMuscleGroup.TryGetValue(Day.Label, out var selectedGroup2) || selectedGroup2 == null))
         {
             <select class="block w-full text-sm border border-gray-300 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    @onchange="e => MuscleGroupChanged?.Invoke(Day.DayOfWeek, e?.Value ?? string.Empty)">
+                    @onchange="e => MuscleGroupChanged?.Invoke(Day.Label, e?.Value ?? string.Empty)">
                 <option value="">-- Select Muscle Group --</option>
                 @foreach (var i in Enum.GetValues<MuscleGroups>())
                 {
@@ -82,7 +82,7 @@
                 }
             </select>
         }
-        else if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.DayOfWeek, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.DayOfWeek, out var muscleGroup) && muscleGroup != null && !GetExercisesForDay(Day.DayOfWeek).Any())
+        else if (!Day.Exercises.Any(ex => EditingExercises.Contains((Day.Label, ex.Exercise?.Id ?? 0))) && SelectedMuscleGroup.TryGetValue(Day.Label, out var muscleGroup) && muscleGroup != null && !GetExercisesForDay(Day.Label).Any())
         {
             <div class="text-gray-400 mb-2">No exercises for this muscle group.</div>
         }
@@ -91,20 +91,20 @@
 
 @code {
     [Parameter] public WorkoutTemplateDay Day { get; set; } = default!;
-    [Parameter] public HashSet<(DayOfWeek, int)> EditingExercises { get; set; } = new();
+    [Parameter] public HashSet<(string, int)> EditingExercises { get; set; } = new();
     [Parameter] public Action<WorkoutTemplateDay, WorkoutTemplateDayExercise>? RemoveExercise { get; set; }
-    [Parameter] public Action<DayOfWeek, int>? StartEditingExercise { get; set; }
-    [Parameter] public Action<DayOfWeek, int>? StopEditingExercise { get; set; }
-    [Parameter] public Func<DayOfWeek, IEnumerable<Exercise>> GetExercisesForDay { get; set; } = default!;
+    [Parameter] public Action<string, int>? StartEditingExercise { get; set; }
+    [Parameter] public Action<string, int>? StopEditingExercise { get; set; }
+    [Parameter] public Func<string, IEnumerable<Exercise>> GetExercisesForDay { get; set; } = default!;
     [Parameter] public Action<WorkoutTemplateDay, object, WorkoutTemplateDayExercise?>? ExerciseSelected { get; set; }
-    [Parameter] public Dictionary<DayOfWeek, MuscleGroups?> SelectedMuscleGroup { get; set; } = new();
-    [Parameter] public Action<DayOfWeek, object>? MuscleGroupChanged { get; set; }
-    [Parameter] public Action<DayOfWeek>? RemoveSelectedMuscleGroup { get; set; }
+    [Parameter] public Dictionary<string, MuscleGroups?> SelectedMuscleGroup { get; set; } = new();
+    [Parameter] public Action<string, object>? MuscleGroupChanged { get; set; }
+    [Parameter] public Action<string>? RemoveSelectedMuscleGroup { get; set; }
 
     private Task HandleExerciseChange(ChangeEventArgs e, WorkoutTemplateDayExercise ex)
     {
         ExerciseSelected?.Invoke(Day, e.Value ?? string.Empty, ex);
-        StopEditingExercise?.Invoke(Day.DayOfWeek, ex.Exercise?.Id ?? 0);
+        StopEditingExercise?.Invoke(Day.Label, ex.Exercise?.Id ?? 0);
         return Task.CompletedTask;
     }
 }

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -44,6 +44,15 @@ public class ApplicationDbContext : DbContext
             .HasOne(md => md.WorkoutTemplate)
             .WithMany(m => m.Days)
             .HasForeignKey(md => md.WorkoutTemplateId);
+        modelBuilder.Entity<WorkoutTemplateDay>()
+            .Property(md => md.DayOfWeek)
+            .IsRequired();
+        modelBuilder.Entity<WorkoutTemplateDay>()
+            .Property(md => md.Label)
+            .IsRequired();
+        modelBuilder.Entity<WorkoutTemplateDay>()
+            .Property(md => md.OrderNumber)
+            .IsRequired();
 
         // WorkoutTemplateDay -> Exercises
         modelBuilder.Entity<WorkoutTemplateDayExercise>()

--- a/Data/ApplicationDbContextModelSnapshot.cs
+++ b/Data/ApplicationDbContextModelSnapshot.cs
@@ -620,10 +620,14 @@ namespace Swol.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("DayNumber")
+                    b.Property<int>("DayOfWeek")
                         .HasColumnType("int");
 
-                    b.Property<int>("DayOfWeek")
+                    b.Property<string>("Label")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("OrderNumber")
                         .HasColumnType("int");
 
                     b.Property<int>("WorkoutTemplateId")

--- a/Data/Models/Template/WorkoutTemplateDay.cs
+++ b/Data/Models/Template/WorkoutTemplateDay.cs
@@ -6,6 +6,7 @@ public class WorkoutTemplateDay
     public int WorkoutTemplateId { get; set; }
     public WorkoutTemplate WorkoutTemplate { get; set; } = null!;
     public DayOfWeek DayOfWeek { get; set; }
-    public int DayNumber { get; set; } // Added for workout progression
+    public string Label { get; set; } = string.Empty;
+    public int OrderNumber { get; set; }
     public ICollection<WorkoutTemplateDayExercise> Exercises { get; set; } = new List<WorkoutTemplateDayExercise>();
 }

--- a/Migrations/20250622210805_InitialCreate.Designer.cs
+++ b/Migrations/20250622210805_InitialCreate.Designer.cs
@@ -623,10 +623,14 @@ namespace Swol.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("DayNumber")
+                    b.Property<int>("DayOfWeek")
                         .HasColumnType("int");
 
-                    b.Property<int>("DayOfWeek")
+                    b.Property<string>("Label")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("OrderNumber")
                         .HasColumnType("int");
 
                     b.Property<int>("WorkoutTemplateId")

--- a/Migrations/20250622210805_InitialCreate.cs
+++ b/Migrations/20250622210805_InitialCreate.cs
@@ -109,7 +109,8 @@ namespace Swol.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     WorkoutTemplateId = table.Column<int>(type: "int", nullable: false),
                     DayOfWeek = table.Column<int>(type: "int", nullable: false),
-                    DayNumber = table.Column<int>(type: "int", nullable: false)
+                    Label = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    OrderNumber = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {


### PR DESCRIPTION
## Summary
- allow flexible labeling and ordering for workout template days
- default new templates to three days
- update workout creation to read template day order and labels
- sync database schema for new template day properties

## Testing
- `dotnet format` *(fails: command not found)*
- `dotnet build Swol.sln` *(fails: command not found)*
- `dotnet test Swol.Tests/Swol.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685871d570c88324a3bee1db865b1e5c